### PR TITLE
fix: setoffset

### DIFF
--- a/src/Pages/Branch/Manager/index.js
+++ b/src/Pages/Branch/Manager/index.js
@@ -125,7 +125,7 @@ const Manager = ({
       pathname,
       search: ''
     })
-    setoffset(0)
+    setoffset(1)
     getBranchs({})
   }
 

--- a/src/Pages/Driver/Manager/index.js
+++ b/src/Pages/Driver/Manager/index.js
@@ -124,7 +124,7 @@ const Manager = ({
       pathname,
       search: ''
     })
-    setoffset(0)
+    setoffset(1)
     getDrivers({})
   }
 

--- a/src/Pages/MaintenanceOrder/Manager/index.js
+++ b/src/Pages/MaintenanceOrder/Manager/index.js
@@ -209,7 +209,7 @@ const Manager = ({
       pathname,
       search: ''
     })
-    setoffset(0)
+    setoffset(1)
     getAllMaintenances({})
   }
 

--- a/src/Pages/MyTeam/Manager/index.js
+++ b/src/Pages/MyTeam/Manager/index.js
@@ -109,7 +109,7 @@ const Manager = ({
       pathname,
       search: ''
     })
-    setoffset(0)
+    setoffset(1)
     getUsers()
   }
 

--- a/src/Pages/Operation/Manager/index.js
+++ b/src/Pages/Operation/Manager/index.js
@@ -126,7 +126,7 @@ const Manager = ({
       pathname,
       search: ''
     })
-    setoffset(0)
+    setoffset(1)
     getOperations({})
   }
 

--- a/src/Pages/Vehicle/Manager/index.js
+++ b/src/Pages/Vehicle/Manager/index.js
@@ -125,7 +125,7 @@ const Manager = ({
       pathname,
       search: ''
     })
-    setoffset(0)
+    setoffset(1)
     getVehicles()
   }
 

--- a/src/Pages/VehicleType/Manager/index.js
+++ b/src/Pages/VehicleType/Manager/index.js
@@ -111,7 +111,7 @@ const Manager = ({
       pathname,
       search: ''
     })
-    setoffset(0)
+    setoffset(1)
     getVehicleTye({})
 
   }


### PR DESCRIPTION
## Contexto
Corrigir a função que limpa filtro.
quando limpa o filtro de algumas telas o tabels fica com "no data", isso porque quando limpavamos o filtro estavamos setando o offset como 0, porém o a paginação do ant começa do 1, por isso estava ocorrenso o erro.